### PR TITLE
Fixed the isolateDisplay not rendering bug

### DIFF
--- a/src/components/displayPages/isolateDisplay.js
+++ b/src/components/displayPages/isolateDisplay.js
@@ -82,7 +82,7 @@ export default ({
 }) => {
   const [searchFilter, setSearchFilter] = useState('')
   const sortedConsistentNames = useMemo(
-    () => isolateInfo.consistentNames
+    () => (isolateInfo.consistentNames || [])
       .concat()
       .sort((a, b) => a > b ? 1 : a < b ? -1 : 0),
     [isolateInfo.consistentNames]


### PR DESCRIPTION
Fixes the bug where the Isolate Display would not render correctly if the `consistentNames` was null.