### PR TITLE
Do not encode DOI for study pages

### DIFF
--- a/src/components/searchPage.js
+++ b/src/components/searchPage.js
@@ -113,7 +113,7 @@ const typeRequest = {
       ['Study title', r => (
         <Link
           className='py-2'
-          to={`/study/${window.encodeURIComponent(r.encodedDOI)}`}
+          to={`/study/${r.encodedDOI}`}
           target='_blank'
         >
           {r.Title}


### PR DESCRIPTION
Do not encode DOI for study pages.
Seeing if this fix some study links.